### PR TITLE
build version 1.1.5

### DIFF
--- a/webapp-manager.spec
+++ b/webapp-manager.spec
@@ -1,5 +1,5 @@
 Name:    webapp-manager
-Version: 1.1.1
+Version: 1.1.5
 Release: 1%{?dist}
 Summary: Web Application Manager
 License: GPLv3+


### PR DESCRIPTION
Latest version of `webapp-manager` seems to build fine. 
I made a quick test here: https://copr.fedorainfracloud.org/coprs/phil/mint-webapp-manager/build/2950152/
If possible please also enable fedora 35.

I have no experience in copr/rpm building. Did you create the .spec file from scratch?